### PR TITLE
Woo titles

### DIFF
--- a/base.php
+++ b/base.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Base Template
+ * Base Template.
  *
  * This file contains the base structure of a BoldGrid Theme.
  *
@@ -17,12 +17,12 @@ $bgtfw_configs = $boldgrid_theme_framework->get_configs();
 	<?php get_template_part( 'templates/head' ); ?>
 	<body <?php body_class(); ?>>
 		<?php
-			// Invoking core hook for plugins to hook first in place on the body content. Ref: https://core.trac.wordpress.org/ticket/46679
+			// Invoking core hook for plugins to hook first in place on the body content. Ref: https://core.trac.wordpress.org/ticket/46679.
 			do_action( 'wp_body_open' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		?>
 		<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'prime' ); ?></a>
 		<?php do_action( 'boldgrid_header_before' ); ?>
-		<div <?php BoldGrid::add_class( 'site_header', [ 'bgtfw-header', 'site-header' ] ); ?>>
+		<div <?php BoldGrid::add_class( 'site_header', array( 'bgtfw-header', 'site-header' ) ); ?>>
 			<?php
 				// Invoking core hook for plugins to hook into header.
 				do_action( 'get_header' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
@@ -31,17 +31,17 @@ $bgtfw_configs = $boldgrid_theme_framework->get_configs();
 		</div><!-- /.header -->
 		<?php do_action( 'boldgrid_header_after' ); ?>
 		<?php do_action( 'boldgrid_content_before' ); ?>
-		<div id="content" <?php BoldGrid::add_class( 'site_content', [ 'site-content' ] ); ?> role="document">
+		<div id="content" <?php BoldGrid::add_class( 'site_content', array( 'site-content' ) ); ?> role="document">
 			<?php if ( 'above' === get_theme_mod( 'bgtfw_global_title_position' ) && ! $boldgrid_theme_framework->woo->is_woocommerce_page() ) : ?>
 				<?php get_template_part( 'templates/page-headers' ); ?>
 			<?php endif; ?>
-			<div id="main-wrapper" <?php BoldGrid::add_class( 'main_wrapper', [ 'main-wrapper' ] ); ?>>
-				<main <?php BoldGrid::add_class( 'main', [ 'main' ] ); ?>>
+			<div id="main-wrapper" <?php BoldGrid::add_class( 'main_wrapper', array( 'main-wrapper' ) ); ?>>
+				<main <?php BoldGrid::add_class( 'main', array( 'main' ) ); ?>>
 					<?php if ( 'above' !== get_theme_mod( 'bgtfw_global_title_position' ) && ! $boldgrid_theme_framework->woo->is_woocommerce_page() ) : ?>
 						<?php get_template_part( 'templates/page-headers' ); ?>
 					<?php endif; ?>
 					<?php do_action( 'boldgrid_main_top' ); ?>
-					<?php include Boldgrid_Framework_Wrapper::boldgrid_template_path(); ?>
+					<?php require Boldgrid_Framework_Wrapper::boldgrid_template_path(); ?>
 					<?php do_action( 'boldgrid_main_bottom' ); ?>
 				</main><!-- /.main -->
 				<?php if ( BoldGrid::display_sidebar() && ( ( function_exists( 'is_woocommerce' ) && is_woocommerce() ) || 'above' !== get_theme_mod( 'bgtfw_global_title_position' ) ) ) : ?>

--- a/base.php
+++ b/base.php
@@ -32,12 +32,12 @@ $bgtfw_configs = $boldgrid_theme_framework->get_configs();
 		<?php do_action( 'boldgrid_header_after' ); ?>
 		<?php do_action( 'boldgrid_content_before' ); ?>
 		<div id="content" <?php BoldGrid::add_class( 'site_content', [ 'site-content' ] ); ?> role="document">
-			<?php if ( 'above' === get_theme_mod( 'bgtfw_global_title_position' ) ) : ?>
+			<?php if ( 'above' === get_theme_mod( 'bgtfw_global_title_position' ) && ! $boldgrid_theme_framework->woo->is_woocommerce_page() ) : ?>
 				<?php get_template_part( 'templates/page-headers' ); ?>
 			<?php endif; ?>
 			<div id="main-wrapper" <?php BoldGrid::add_class( 'main_wrapper', [ 'main-wrapper' ] ); ?>>
 				<main <?php BoldGrid::add_class( 'main', [ 'main' ] ); ?>>
-					<?php if ( 'above' !== get_theme_mod( 'bgtfw_global_title_position' ) ) : ?>
+					<?php if ( 'above' !== get_theme_mod( 'bgtfw_global_title_position' ) && ! $boldgrid_theme_framework->woo->is_woocommerce_page() ) : ?>
 						<?php get_template_part( 'templates/page-headers' ); ?>
 					<?php endif; ?>
 					<?php do_action( 'boldgrid_main_top' ); ?>


### PR DESCRIPTION
Removes duplicate H1 headers on shop page and product pages to fix #66 
By removing the duplicate headers this also resolves #67 