### PR TITLE
skip normal templating if is pdf or genpdf

### DIFF
--- a/base.php
+++ b/base.php
@@ -11,14 +11,6 @@
 global $boldgrid_theme_framework;
 global $post;
 
-if ( ! empty( $post ) && class_exists( 'SI_Invoice' ) ) {
-	$is_sa_invoice  = SI_Invoice::is_invoice_query();
-	$is_sa_estimate = 'sa_estimate' === $post->post_type;
-} else {
-	$is_sa_invoice  = false;
-	$is_sa_estimate = false;
-}
-
 $bgtfw_configs = $boldgrid_theme_framework->get_configs();
 
 $has_header_template = apply_filters( 'crio_premium_get_page_header', get_the_ID() );
@@ -28,21 +20,13 @@ $template_has_title  = get_post_meta( $has_header_template, 'crio-premium-templa
 $has_sticky_template = apply_filters( 'crio_premium_get_sticky_page_header', get_the_ID() );
 $has_sticky_template = get_the_ID() === $has_sticky_template ? false : $has_sticky_template;
 
-if ( ! isset( $_REQUEST[ 'pdf' ] ) && ! isset( $_REQUEST[ 'genpdf'] ) ) {
 ?>
 <!doctype html>
 <!-- BGTFW Version: <?php echo esc_html( $bgtfw_configs['framework-version'] ); ?> -->
 <html <?php language_attributes(); ?>>
 <?php
-if ( $is_sa_estimate ) {
-	$template = SI_Templating_API::override_template( 'estimate' );
-	load_template( $template );
-} elseif ( $is_sa_invoice ) {
-	$template = SI_Templating_API::override_template( 'invoice' );
-	load_template( $template );
-} else {
 	get_template_part( 'templates/head' );
-	?>
+?>
 	<body
 	<?php
 	body_class();
@@ -113,13 +97,4 @@ if ( $is_sa_estimate ) {
 		<?php wp_footer(); ?>
 		<?php do_action( 'boldgrid_footer_after' ); ?>
 	</body>
-				<?php } ?>
 </html>
-<?php } elseif ( $is_sa_estimate ) {
-	$template = SI_Templating_API::override_template( 'estimate' );
-	load_template( $template );
-} elseif ( $is_sa_invoice ) {
-	$template = SI_Templating_API::override_template( 'invoice' );
-	load_template( $template );
-}
-?>

--- a/base.php
+++ b/base.php
@@ -28,6 +28,7 @@ $template_has_title  = get_post_meta( $has_header_template, 'crio-premium-templa
 $has_sticky_template = apply_filters( 'crio_premium_get_sticky_page_header', get_the_ID() );
 $has_sticky_template = get_the_ID() === $has_sticky_template ? false : $has_sticky_template;
 
+if ( ! isset( $_REQUEST[ 'pdf' ] ) && ! isset( $_REQUEST[ 'genpdf'] ) ) {
 ?>
 <!doctype html>
 <!-- BGTFW Version: <?php echo esc_html( $bgtfw_configs['framework-version'] ); ?> -->
@@ -114,3 +115,11 @@ if ( $is_sa_estimate ) {
 	</body>
 				<?php } ?>
 </html>
+<?php } elseif ( $is_sa_estimate ) {
+	$template = SI_Templating_API::override_template( 'estimate' );
+	load_template( $template );
+} elseif ( $is_sa_invoice ) {
+	$template = SI_Templating_API::override_template( 'invoice' );
+	load_template( $template );
+}
+?>

--- a/si-estimate-base.php
+++ b/si-estimate-base.php
@@ -10,4 +10,3 @@
 
 $template = SI_Templating_API::override_template( 'estimate' );
 load_template( $template );
-?>

--- a/si-estimate-base.php
+++ b/si-estimate-base.php
@@ -8,16 +8,7 @@
  * @package Prime
  */
 
-global $boldgrid_theme_framework;
-
-$bgtfw_configs = $boldgrid_theme_framework->get_configs();
-
-?>
-<!doctype html>
-<!-- BGTFW Version: <?php echo esc_html( $bgtfw_configs['framework-version'] ); ?> -->
-<html <?php language_attributes(); ?>>
-<?php
-	$template = SI_Templating_API::override_template( 'estimate' );
-	load_template( $template );
+$template = SI_Templating_API::override_template( 'estimate' );
+load_template( $template );
 ?>
 </html>

--- a/si-estimate-base.php
+++ b/si-estimate-base.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Base Template.
+ *
+ * This file contains the base structure of a BoldGrid Theme.
+ *
+ * @since 2.0
+ * @package Prime
+ */
+
+global $boldgrid_theme_framework;
+
+$bgtfw_configs = $boldgrid_theme_framework->get_configs();
+error_log( 'si-estimate-base loaded' );
+
+?>
+<!doctype html>
+<!-- BGTFW Version: <?php echo esc_html( $bgtfw_configs['framework-version'] ); ?> -->
+<html <?php language_attributes(); ?>>
+<?php
+	$template = SI_Templating_API::override_template( 'estimate' );
+	load_template( $template );
+?>
+</html>

--- a/si-estimate-base.php
+++ b/si-estimate-base.php
@@ -11,7 +11,6 @@
 global $boldgrid_theme_framework;
 
 $bgtfw_configs = $boldgrid_theme_framework->get_configs();
-error_log( 'si-estimate-base loaded' );
 
 ?>
 <!doctype html>

--- a/si-estimate-base.php
+++ b/si-estimate-base.php
@@ -11,4 +11,3 @@
 $template = SI_Templating_API::override_template( 'estimate' );
 load_template( $template );
 ?>
-</html>

--- a/si-invoice-base.php
+++ b/si-invoice-base.php
@@ -10,4 +10,3 @@
 
 $template = SI_Templating_API::override_template( 'invoice' );
 load_template( $template );
-?>

--- a/si-invoice-base.php
+++ b/si-invoice-base.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Base Template.
+ *
+ * This file contains the base structure of a BoldGrid Theme.
+ *
+ * @since 2.0
+ * @package Prime
+ */
+
+global $boldgrid_theme_framework;
+
+$bgtfw_configs = $boldgrid_theme_framework->get_configs();
+error_log( 'si-invoice-base loaded' );
+
+?>
+<!doctype html>
+<!-- BGTFW Version: <?php echo esc_html( $bgtfw_configs['framework-version'] ); ?> -->
+<html <?php language_attributes(); ?>>
+<?php
+	$template = SI_Templating_API::override_template( 'invoice' );
+	load_template( $template );
+?>
+</html>

--- a/si-invoice-base.php
+++ b/si-invoice-base.php
@@ -8,16 +8,7 @@
  * @package Prime
  */
 
-global $boldgrid_theme_framework;
-
-$bgtfw_configs = $boldgrid_theme_framework->get_configs();
-
-?>
-<!doctype html>
-<!-- BGTFW Version: <?php echo esc_html( $bgtfw_configs['framework-version'] ); ?> -->
-<html <?php language_attributes(); ?>>
-<?php
-	$template = SI_Templating_API::override_template( 'invoice' );
-	load_template( $template );
+$template = SI_Templating_API::override_template( 'invoice' );
+load_template( $template );
 ?>
 </html>

--- a/si-invoice-base.php
+++ b/si-invoice-base.php
@@ -11,7 +11,6 @@
 global $boldgrid_theme_framework;
 
 $bgtfw_configs = $boldgrid_theme_framework->get_configs();
-error_log( 'si-invoice-base loaded' );
 
 ?>
 <!doctype html>

--- a/si-invoice-base.php
+++ b/si-invoice-base.php
@@ -11,4 +11,3 @@
 $template = SI_Templating_API::override_template( 'invoice' );
 load_template( $template );
 ?>
-</html>

--- a/si-pdf-base.php
+++ b/si-pdf-base.php
@@ -5,7 +5,7 @@
  * This file is used when sprout invoices generates a pdf.
  */
 global $post;
-error_log( 'si-pdf-base loaded' );
+
 if ( ! empty( $post ) && class_exists( 'SI_Invoice' ) ) {
 	$is_sa_invoice  = SI_Invoice::is_invoice_query();
 	$is_sa_estimate = 'sa_estimate' === $post->post_type;
@@ -15,9 +15,7 @@ if ( ! empty( $post ) && class_exists( 'SI_Invoice' ) ) {
 }
 
 if ( $is_sa_estimate ) {
-	error_log( 'is sa estimate' );
 	$template = SI_Templating_API::override_template( 'estimate' );
-	error_log( 'template: ' . $template );
 	load_template( $template );
 } elseif ( $is_sa_invoice ) {
 	$template = SI_Templating_API::override_template( 'invoice' );

--- a/si-pdf-base.php
+++ b/si-pdf-base.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * File: pdf.php
+ *
+ * This file is used when sprout invoices generates a pdf.
+ */
+global $post;
+error_log( 'si-pdf-base loaded' );
+if ( ! empty( $post ) && class_exists( 'SI_Invoice' ) ) {
+	$is_sa_invoice  = SI_Invoice::is_invoice_query();
+	$is_sa_estimate = 'sa_estimate' === $post->post_type;
+} else {
+	$is_sa_invoice  = false;
+	$is_sa_estimate = false;
+}
+
+if ( $is_sa_estimate ) {
+	error_log( 'is sa estimate' );
+	$template = SI_Templating_API::override_template( 'estimate' );
+	error_log( 'template: ' . $template );
+	load_template( $template );
+} elseif ( $is_sa_invoice ) {
+	$template = SI_Templating_API::override_template( 'invoice' );
+	load_template( $template );
+}


### PR DESCRIPTION
Resolves #146 


### Testing Instructions ###
1. install Crio test zip,
[crio.zip](https://github.com/BoldGrid/prime/files/9902903/crio.zip)

2. Install Sprout Invoices Pro (Business +) and activate license
3. go into Sprout Invoices -> add-on's
4. Enable PDF Service for WordPress Invoices & Estimates
5. Create a new Estimate
6. Set a quanity, Rate
7. Check Redirect to Invoice in the Estimnate Acceptance Actions
8. View Estimate
9. Click on the PDF and verify it looks like the estimate
10. Click Accept Estimate
11. Should redirect you to the invoice and you should see the PDF icon
12. Click on the PDF and verify it looks like the invoice